### PR TITLE
Added swagger support for QueryParams

### DIFF
--- a/examples/src/main/scala/ru/tinkoff/tschema/examples/TestModule.scala
+++ b/examples/src/main/scala/ru/tinkoff/tschema/examples/TestModule.scala
@@ -44,11 +44,13 @@ object definitions {
 
   def stats = post |> operation('stats) |> reqBody[Seq[BigDecimal]] |> $$[StatsRes]
 
+  def statsq = get |> operation('statsq) |> queryParams[BigDecimal]('num) |> $$[StatsRes]
+
   def intops = queryParam[Client]('x) |> (combine ~ sum)
 
   def dist = operation('sqrtMean) |> formField[Double]('a) |> formField[Double]('b) |> post[Double]
 
-  def api = tagPrefix('test) |> (concat <> intops <> stats <> dist)
+  def api = tagPrefix('test) |> (concat <> intops <> stats <> statsq <> dist)
 }
 
 object TestModule extends ExampleModule {
@@ -86,6 +88,8 @@ object TestModule extends ExampleModule {
       val std = body.view.map(x => x * x).sum / body.size - mean * mean
       StatsRes(mean, std, median)
     }
+
+    def statsq(num: Seq[BigDecimal]) = stats(num)
   }
 
   val swag = MkSwagger(api)(())

--- a/publish.sbt
+++ b/publish.sbt
@@ -11,7 +11,7 @@ publishTo in ThisBuild := Some(
     Opts.resolver.sonatypeStaging
 )
 
-val pubVersion = "0.10.4"
+val pubVersion = "0.10.5"
 
 credentials in ThisBuild += Credentials(Path.userHome / ".sbt" / ".ossrh-credentials")
 

--- a/src/main/scala/ru/tinkoff/tschema/swagger/OpenApi.scala
+++ b/src/main/scala/ru/tinkoff/tschema/swagger/OpenApi.scala
@@ -115,7 +115,10 @@ final case class OpenApiParam(name: String,
                               in: OpenApiParam.In,
                               description: Option[SwaggerDescription] = None,
                               required: Boolean = true,
-                              schema: Option[SwaggerType] = None)
+                              schema: Option[SwaggerType] = None,
+                              deprecated: Boolean = false,
+                              allowEmptyValue: Boolean = false,
+)
 
 object OpenApiParam {
   sealed trait In extends EnumEntry


### PR DESCRIPTION
Akka-Http `QueryParams[T]` now requires at least one value, support for `QueryParams[Option[T]]`, that may extract empty List