### PR TITLE
Bump cats to 1.4.0, use FunctorFilter, remove cats-mtl

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -37,6 +37,8 @@ libraryDependencies += "org.scalameta" %% "scalameta" % "1.8.0"
 
 libraryDependencies += "com.propensive" %% "magnolia" % "0.7.1"
 
+libraryDependencies += "com.github.mpilquist" %% "simulacrum" % Version.simulacrum
+
 addCompilerPlugin("org.spire-math" %% "kind-projector" % Version.kindProjector)
 
 

--- a/macros/build.sbt
+++ b/macros/build.sbt
@@ -3,7 +3,6 @@ name := "typed-schema-macros"
 libraryDependencies += scalaOrganization.value % "scala-reflect" % scalaVersion.value
 libraryDependencies += "com.chuusai" %% "shapeless" % Version.shapeless
 libraryDependencies += "org.typelevel" %% "cats-core" % Version.cats
-libraryDependencies += "org.typelevel" %% "cats-mtl-core" % Version.catsMtl
 libraryDependencies += "com.typesafe.akka" %% "akka-http" % Version.akkaHttp
 libraryDependencies += "com.typesafe.akka" %% "akka-http-testkit" % Version.akkaHttp % "test"
 

--- a/project/Version.scala
+++ b/project/Version.scala
@@ -7,11 +7,11 @@ object Version {
   val shapeless = "2.3.3"
   val kindProjector = "0.9.3"
   val akkaHttpCirce = "1.19.0"
-  val cats = "1.1.0"
-  val catsMtl = "0.2.2"
+  val cats = "1.4.0"
   val enumeratum = "1.5.12"
   val enumeratumCirce = "1.5.15"
   val monocle = "1.5.1-cats"
+  val simulacrum = "0.13.0"
 
   val scalaTest = "3.0.1"
   val scalaCheck = "1.13.4"

--- a/src/main/scala/ru/tinkoff/tschema/akkaHttp/catsInstances.scala
+++ b/src/main/scala/ru/tinkoff/tschema/akkaHttp/catsInstances.scala
@@ -1,13 +1,12 @@
 package ru.tinkoff.tschema.akkaHttp
 import akka.http.scaladsl.server.Directives._
 import akka.http.scaladsl.server.{Directive, Directive1, Rejection}
-import cats.mtl.FunctorEmpty
-import cats.{Monad, MonoidK}
+import cats.{Monad, MonoidK, FunctorFilter}
 
 object catsInstances {
   case object FilterRejection extends Rejection
 
-  implicit val directive1Instance = new Monad[Directive1] with MonoidK[Directive1] with FunctorEmpty[Directive1]{
+  implicit val directive1Instance = new Monad[Directive1] with MonoidK[Directive1] with FunctorFilter[Directive1]{
     def pure[A](x: A): Directive1[A] = provide(x)
     def empty[A]: Directive1[A] = Directive(_ => reject(FilterRejection))
     def flatMap[A, B](fa: Directive1[A])(f: (A) => Directive1[B]): Directive1[B] = fa.flatMap(f)
@@ -19,8 +18,6 @@ object catsInstances {
     override def filter[A](fa: Directive1[A])(f: (A) => Boolean): Directive1[A] = fa.filter(f)
     override def map[A, B](fa: Directive1[A])(f: (A) => B): Directive1[B] = fa.map(f)
     val functor = this
-    def mapFilter[A, B](fa: Directive1[A])(f: (A) => Option[B]) = ???
-    def collect[A, B](fa: Directive1[A])(f: PartialFunction[A, B]) = ???
-    def flattenOption[A](fa: Directive1[Option[A]]) = ???
+    override def mapFilter[A, B](fa: Directive1[A])(f: A => Option[B]): Directive1[B] = ???
   }
 }


### PR DESCRIPTION
Since cats 1.4.0 & cats-mtl mtl's FunctorEmpty moved into cats as FunctorFilter