### PR TITLE
Replace monocle with tofu-optics

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,7 @@ dist: xenial
 language: scala
 
 scala:
-  - 2.11.12
+#  - 2.11.12
   - 2.12.10
 #  - 2.13.1
 

--- a/build.sbt
+++ b/build.sbt
@@ -77,9 +77,9 @@ val paradise = libraryDependencies ++= {
 
 val magnolia = libraryDependencies += "com.propensive" %% "magnolia" % Version.magnolia
 
-val monocle = libraryDependencies ++= List("core", "macro").map(
+val tofuOptics = libraryDependencies ++= List("core", "macro").map(
   module =>
-    "com.github.julien-truffaut" %% s"monocle-$module" % Version.monocle
+    "ru.tinkoff" %% s"tofu-optics-$module" % Version.tofu
 )
 
 val circe = libraryDependencies ++= List("core", "parser", "generic", "generic-extras").map(
@@ -190,7 +190,7 @@ lazy val swagger = project
     moduleName := "typed-schema-swagger",
     libraryDependencies ++= enumeratum :: enumeratumCirce :: Nil,
     magnolia,
-    monocle,
+    tofuOptics,
     paradise,
     circe
   )

--- a/build.sbt
+++ b/build.sbt
@@ -2,7 +2,6 @@ import com.typesafe.sbt.SbtGit.git
 
 val pubVersion = "0.11.0"
 
-
 val publishSettings = List(
   name := "Typed Schema",
   organization := "ru.tinkoff",
@@ -38,7 +37,7 @@ developers in ThisBuild := List(
 
 val minorVersion = SettingKey[Int]("minor scala version")
 
-val crossCompile = crossScalaVersions := List("2.11.12", "2.12.10")
+val crossCompile = crossScalaVersions := List("2.12.10")
 
 val commonScalacOptions = scalacOptions ++= List(
   "-deprecation",
@@ -50,16 +49,9 @@ val commonScalacOptions = scalacOptions ++= List(
   "-language:postfixOps"
 )
 
-val setExperimental = scalacOptions ++= {
-  CrossVersion.partialVersion(scalaVersion.value) match {
-    case Some((2, y)) if y == 11 => Seq("-Xexperimental")
-    case _                       => Seq.empty[String]
-  }
-}
-
 val specificScalacOptions = scalacOptions ++= {
   minorVersion.value match {
-    case 11 | 12 => List("-Ypartial-unification")
+    case 12 => List("-Ypartial-unification")
     case 13      => List("-Ymacro-annotations")
   }
 }
@@ -78,56 +70,26 @@ lazy val compilerPlugins = libraryDependencies ++= List(
 
 val paradise = libraryDependencies ++= {
   minorVersion.value match {
-    case 11 | 12 => List(compilerPlugin("org.scalamacros" % "paradise" % "2.1.1" cross CrossVersion.patch))
+    case 12 => List(compilerPlugin("org.scalamacros" % "paradise" % "2.1.1" cross CrossVersion.patch))
     case 13      => List()
   }
 }
 
-val magnolia = libraryDependencies += "com.propensive" %% "magnolia" % {
-  minorVersion.value match {
-    case 11 => Version.magnolia211
-    case _  => Version.magnolia213
-  }
-}
+val magnolia = libraryDependencies += "com.propensive" %% "magnolia" % Version.magnolia
 
 val monocle = libraryDependencies ++= List("core", "macro").map(
   module =>
-    "com.github.julien-truffaut" %% s"monocle-$module" % {
-      minorVersion.value match {
-        case 11 | 12 => Version.monocle
-        case 13      => Version.monocle213
-      }
-    }
+    "com.github.julien-truffaut" %% s"monocle-$module" % Version.monocle
 )
 
 val circe = libraryDependencies ++= List("core", "parser", "generic", "generic-extras").map(
   module =>
-    "io.circe" %% s"circe-$module" % {
-      minorVersion.value match {
-        case 11      => Version.circe211
-        case 12 | 13 => Version.circe
-      }
-    }
-) :+ "io.circe" %% "circe-derivation" % {
-  minorVersion.value match {
-    case 11      => Version.circe211
-    case 12 | 13 => Version.circeDerivation
-  }
-}
+    "io.circe" %% s"circe-$module" % Version.circe
+) :+ "io.circe" %% "circe-derivation" % Version.circeDerivation
 
-val scalatags = libraryDependencies += "com.lihaoyi" %% "scalatags" % {
-  minorVersion.value match {
-    case 11      => Version.scalaTags211
-    case 12 | 13 => Version.scalaTags
-  }
-}
+val scalatags = libraryDependencies += "com.lihaoyi" %% "scalatags" % Version.scalaTags
 
-val akkaHttpCirce = libraryDependencies += "de.heikoseeberger" %% "akka-http-circe" % {
-  minorVersion.value match {
-    case 11      => Version.akkaHttpCirce211
-    case 12 | 13 => Version.akkaHttpCirce
-  }
-}
+val akkaHttpCirce = libraryDependencies += "de.heikoseeberger" %% "akka-http-circe" % Version.akkaHttpCirce
 
 val catsCore   = "org.typelevel"        %% s"cats-core"   % Version.cats
 val catsFree   = "org.typelevel"        %% s"cats-free"   % Version.cats
@@ -174,7 +136,6 @@ lazy val commonSettings = publishSettings ++ List(
   scalaVersion := "2.12.10",
   compilerPlugins,
   commonScalacOptions,
-  setExperimental,
   specificScalacOptions,
   crossCompile,
   setMinorVersion,

--- a/modules/swagger/src/main/scala/ru/tinkoff/tschema/swagger/MkSwagger.scala
+++ b/modules/swagger/src/main/scala/ru/tinkoff/tschema/swagger/MkSwagger.scala
@@ -17,7 +17,7 @@ import ru.tinkoff.tschema.swagger.SwaggerBuilder.EmptySwaggerBuilder
 import ru.tinkoff.tschema.swagger.SwaggerMapper.derivedParamAtom
 import ru.tinkoff.tschema.typeDSL._
 import ru.tinkoff.tschema.utils.subsets._
-import tofu.optics.Contains
+import tofu.optics.{Contains, chain}
 import tofu.optics.functions._
 import tofu.optics.macros.GenContains
 import shapeless.{Lazy, Witness}
@@ -112,8 +112,8 @@ object SwaggerBuilder {
             (OpenApiOp.summary.update(_, method(MethodTarget.Summary) orElse _)) andThen
             ((OpenApiOp.parameters >> vecItems[OpenApiParam, OpenApiParam])
               .update(_, param => OpenApiParam.description.update(param, method(MethodTarget.Param(param.name)) orElse _))) andThen
-            ((OpenApiOp.requestBody >> some[OpenApiRequestBody] >> OpenApiRequestBody.description)
-              .update(_, method(MethodTarget.Body) orElse _))
+            ((oao: OpenApiOp) => chain(oao) >> 
+              OpenApiOp.requestBody > some >@ () >> OpenApiRequestBody.description update (method(MethodTarget.Body) orElse _))
         )
       case spec => spec
     }

--- a/modules/swagger/src/main/scala/ru/tinkoff/tschema/swagger/SwaggerMapper.scala
+++ b/modules/swagger/src/main/scala/ru/tinkoff/tschema/swagger/SwaggerMapper.scala
@@ -20,7 +20,8 @@ import ru.tinkoff.tschema.swagger.SwaggerBuilder.EmptySwaggerBuilder
 import ru.tinkoff.tschema.swagger.SwaggerMapper.derivedParamAtom
 import ru.tinkoff.tschema.typeDSL._
 import ru.tinkoff.tschema.utils.subsets._
-import tofu.optics.functions.mapAt
+import tofu.optics.chain
+import tofu.optics.tags.at
 import shapeless.{Lazy, Witness}
 
 import scala.annotation.implicitNotFound
@@ -237,9 +238,9 @@ object SwaggerMapper extends SwaggerMapperInstances1 {
     def make: OpenApiRequestBody =
       OpenApiRequestBody(content = Map(myMediaType -> OpenApiMediaType(schema = objType.some)))
 
-    def add: OpenApiRequestBody => OpenApiRequestBody =
-      (OpenApiRequestBody.content >> mapAt[MediaType, OpenApiMediaType](myMediaType) >> some[OpenApiMediaType] >> OpenApiMediaType.schema >> some[SwaggerType])
-        .update(_, _ merge objType)
+    def add(body: OpenApiRequestBody): OpenApiRequestBody =
+      chain(body) >> OpenApiRequestBody.content > at >@ myMediaType > some >>
+        OpenApiMediaType.schema > some >@ () update (_ merge objType)
   }
 
   object MakeFormField {

--- a/modules/swagger/src/main/scala/ru/tinkoff/tschema/swagger/SwaggerMapper.scala
+++ b/modules/swagger/src/main/scala/ru/tinkoff/tschema/swagger/SwaggerMapper.scala
@@ -11,9 +11,6 @@ import cats.instances.map._
 import cats.instances.vector._
 import cats.kernel.Semigroup
 import cats.{Eval, Monoid, MonoidK}
-import monocle.function.all._
-import monocle.macros.Lenses
-import monocle.std.option.some
 import ru.tinkoff.tschema.common.Name
 import ru.tinkoff.tschema.macros.MakerMacro
 import ru.tinkoff.tschema.swagger.MkSwagger._
@@ -22,6 +19,8 @@ import ru.tinkoff.tschema.swagger.PathDescription.{DescriptionMap, TypeTarget}
 import ru.tinkoff.tschema.swagger.SwaggerBuilder.EmptySwaggerBuilder
 import ru.tinkoff.tschema.swagger.SwaggerMapper.derivedParamAtom
 import ru.tinkoff.tschema.typeDSL._
+import ru.tinkoff.tschema.utils.subsets._
+import tofu.optics.functions.mapAt
 import shapeless.{Lazy, Witness}
 
 import scala.annotation.implicitNotFound
@@ -91,7 +90,7 @@ object SwaggerMapper extends SwaggerMapperInstances1 {
   def fromAuth[T](name: String, auth: OpenApiSecurity) = new Empty[T] {
     override def auths = TreeMap(name -> auth)
     override def mapSpec(spec: PathSpec): PathSpec =
-      (PathSpec.op ^|-> OpenApiOp.security).modify(_ :+ Map(name -> Vector.empty))(spec)
+      (PathSpec.op >> OpenApiOp.security).update(spec, _ :+ Map(name -> Vector.empty))
   }
 
   private[swagger] def derivedParam[name, T, param[_, _]](in: In)(
@@ -118,7 +117,7 @@ object SwaggerMapper extends SwaggerMapperInstances1 {
       case pm: AsMultiOpenApiParam[T]  => pm.fields.map(p => makeSingle(p, p.name)).toList
     }
 
-    fromFunc((PathSpec.op ^|-> OpenApiOp.parameters).modify(_ ++ parameters)) andThen
+    fromFunc((PathSpec.op >> OpenApiOp.parameters).update(_, _ ++ parameters)) andThen
       fromTypes[atom](param.types)
   }
 
@@ -152,7 +151,7 @@ object SwaggerMapper extends SwaggerMapperInstances1 {
         case pm: AsMultiOpenApiParam[T]  => pm.fields.reduceMap(p => param(p, p.name))
       }
 
-      (PathSpec.op ^|-> OpenApiOp.requestBody).modify(
+      (PathSpec.op >> OpenApiOp.requestBody).update(_, 
         _.fold(params.make)(params.add).some
       )
     }
@@ -163,18 +162,18 @@ object SwaggerMapper extends SwaggerMapperInstances1 {
   implicit def deriveAllQuery[x]: SwaggerMapper[AllQuery[x]] = SwaggerMapper.empty
 
   implicit def derivePathParam[name, T: AsOpenApiParam](implicit name: Name[name]) =
-    derivedParam[name, T, Capture](In.path).map(PathSpec.path.modify(s"{$name}" +: _))
+    derivedParam[name, T, Capture](In.path).map(PathSpec.path.update(_, s"{$name}" +: _))
 
   implicit def deriveReqBody[name, T](implicit content: SwaggerContent[T]): SwaggerMapper[ReqBody[name, T]] =
     fromFunc(
-      (PathSpec.op ^|-> OpenApiOp.requestBody).set(OpenApiRequestBody.fromTypes(content.content.flatMap(_._2): _*).some)
+      (PathSpec.op >> OpenApiOp.requestBody).set(_, OpenApiRequestBody.fromTypes(content.content.flatMap(_._2): _*).some)
     ) andThen fromTypes[ReqBody[name, T]](content.collectTypes)
 
   implicit def deriveMethod[method](implicit methodDeclare: MethodDeclare[method]): SwaggerMapper[method] =
-    fromFunc[method](PathSpec.method.modify {
+    fromFunc[method](PathSpec.method.update(_, {
       case None           => methodDeclare.method.some
       case meth @ Some(_) => meth
-    })
+    }))
 
   implicit def deriveCons[start, end](
       implicit start: SwaggerMapper[start],
@@ -183,22 +182,22 @@ object SwaggerMapper extends SwaggerMapperInstances1 {
     (start andThen end).as[start :> end]
 
   private def deriveDesr[T](descr: SwaggerDescription): SwaggerMapper[T] =
-    fromFunc((PathSpec.op ^|-> OpenApiOp.description).set(descr.some))
+    fromFunc((PathSpec.op >> OpenApiOp.description).set(_, descr.some))
 
   implicit def deriveTag[name](implicit name: Name[name]): SwaggerMapper[Tag[name]] =
-    fromFunc((PathSpec.op ^|-> OpenApiOp.tags).modify(_ :+ name.string))
+    fromFunc((PathSpec.op >> OpenApiOp.tags).update(_, _ :+ name.string))
 
   implicit def deriveDeprecated: SwaggerMapper[Deprecated] =
-    fromFunc((PathSpec.op ^|-> OpenApiOp.deprecated).set(true))
+    fromFunc((PathSpec.op >> OpenApiOp.deprecated).set(_, true))
 
   implicit def deriveAs[x, name](implicit internal: Lazy[SwaggerMapper[x]]): SwaggerMapper[As[x, name]] =
     internal.value.as[As[x, name]]
 
   implicit def deriveKey[name](implicit name: Name[name]): SwaggerMapper[Key[name]] =
-    fromFunc(PathSpec.key.set(name.string.some))
+    fromFunc(PathSpec.key.set(_, name.string.some))
 
   implicit def deriveGroup[name](implicit name: Name[name]): SwaggerMapper[Group[name]] =
-    fromFunc(PathSpec.groups.modify(name.string +: _))
+    fromFunc(PathSpec.groups.update(_, name.string +: _))
 
   def swaggerAuth[realm: Name, x, T](
       scheme: Option[OpenApiSecurityScheme] = None,
@@ -239,8 +238,8 @@ object SwaggerMapper extends SwaggerMapperInstances1 {
       OpenApiRequestBody(content = Map(myMediaType -> OpenApiMediaType(schema = objType.some)))
 
     def add: OpenApiRequestBody => OpenApiRequestBody =
-      (OpenApiRequestBody.content ^|-? index(myMediaType) ^|-> OpenApiMediaType.schema ^<-? some)
-        .modify(_ merge objType)
+      (OpenApiRequestBody.content >> mapAt[MediaType, OpenApiMediaType](myMediaType) >> some[OpenApiMediaType] >> OpenApiMediaType.schema >> some[SwaggerType])
+        .update(_, _ merge objType)
   }
 
   object MakeFormField {

--- a/modules/swagger/src/main/scala/ru/tinkoff/tschema/utils/setters.scala
+++ b/modules/swagger/src/main/scala/ru/tinkoff/tschema/utils/setters.scala
@@ -1,8 +1,0 @@
-package ru.tinkoff.tschema.utils
-
-import cats.Eval
-import monocle.{PSetter, Setter}
-
-object setters {
-  def eval[A]: Setter[Eval[A], A] = PSetter(f => _.map(f))
-}

--- a/modules/swagger/src/main/scala/ru/tinkoff/tschema/utils/subsets.scala
+++ b/modules/swagger/src/main/scala/ru/tinkoff/tschema/utils/subsets.scala
@@ -1,0 +1,14 @@
+package ru.tinkoff.tschema.utils
+
+import tofu.optics.Subset
+
+object subsets {
+  def some[A]: Subset[Option[A], A] = new Subset[Option[A], A] {
+    override def narrow(s: Option[A]): Either[Option[A], A] = s match {
+      case None => Left(s)
+      case Some(value) => Right(value)
+    }
+
+    override def upcast(b: A): Option[A] = Some(b)
+  }
+}

--- a/modules/swagger/src/main/scala/ru/tinkoff/tschema/utils/subsets.scala
+++ b/modules/swagger/src/main/scala/ru/tinkoff/tschema/utils/subsets.scala
@@ -1,9 +1,14 @@
 package ru.tinkoff.tschema.utils
 
-import tofu.optics.Subset
+import tofu.optics.tags.{TagApply, TaggerObj}
+import tofu.optics.{PSubset, Subset}
 
 object subsets {
-  def some[A]: Subset[Option[A], A] = new Subset[Option[A], A] {
+  object some extends TaggerObj[PSubset] {
+    implicit def someOption[A]: TagApply[PSubset, Option[A], A, this.type, Unit] = _ => someSubset
+  }
+
+  private def someSubset[A]: Subset[Option[A], A] = new Subset[Option[A], A] {
     override def narrow(s: Option[A]): Either[Option[A], A] = s match {
       case None => Left(s)
       case Some(value) => Right(value)

--- a/modules/swagger/src/main/scala/ru/tinkoff/tschema/utils/updates.scala
+++ b/modules/swagger/src/main/scala/ru/tinkoff/tschema/utils/updates.scala
@@ -1,0 +1,8 @@
+package ru.tinkoff.tschema.utils
+
+import cats.Eval
+import tofu.optics.{PUpdate, Update}
+
+object updates {
+  def eval[A]: Update[Eval[A], A] = (ev, f) => ev.map(f)
+}

--- a/project/Version.scala
+++ b/project/Version.scala
@@ -37,7 +37,7 @@ object Version {
 
   val derevo = "0.8.1"
 
-  val tofu = "0.2.0"
+  val tofu = "0.5.0"
 
   val swaggerUI = "3.24.0"
 

--- a/project/Version.scala
+++ b/project/Version.scala
@@ -3,8 +3,6 @@ object Version {
 
   val circeDerivation = "0.12.0-M7"
 
-  val circe211 = "0.12.0-M3"
-
   val tethys = "0.10.0"
 
   val akka = "2.5.26"
@@ -17,8 +15,6 @@ object Version {
 
   val akkaHttpCirce = "1.29.1"
 
-  val akkaHttpCirce211 = "1.27.0"
-
   val cats = "2.0.0"
 
   val catsEffect = "2.0.0"
@@ -27,15 +23,11 @@ object Version {
 
   val enumeratumCirce = "1.5.22"
 
-  val monocle = "1.5.1-cats"
-
-  val monocle213 = "1.6.0"
+  val monocle = "1.6.0"
 
   val simulacrum = "0.19.0"
 
-  val magnolia211 = "0.10.0"
-
-  val magnolia213 = "0.11.0"
+  val magnolia = "0.11.0"
 
   val zio = "1.0.0-RC15"
 
@@ -48,8 +40,6 @@ object Version {
   val tofu = "0.2.0"
 
   val swaggerUI = "3.24.0"
-
-  val scalaTags211 = "0.6.8"
 
   val scalaTags = "0.7.0"
 


### PR DESCRIPTION
This PR replaces monocle with shiny new tofu optics together with dropping Scala 2.11 support