### PR TITLE
Improve error reporting for `makeRouteImpl` macro

### DIFF
--- a/modules/finagle/src/main/scala/ru/tinkoff/tschema/finagle/MkService.scala
+++ b/modules/finagle/src/main/scala/ru/tinkoff/tschema/finagle/MkService.scala
@@ -37,7 +37,7 @@ object MkService {
     }
 
     class ServePA[F[_], T] {
-      def apply[In, Out](in: In)(implicit serve: Serve[T, F, In, Out], F: FlatMap[F]) = new ServePA2[F, T, In, Out](in)(serve)
+      def apply[In, Out](in: In)(implicit F: Monad[F], serve: Serve[T, F, In, Out]) = new ServePA2[F, T, In, Out](in)(serve)
     }
 
     class ServePA2[F[_]: FlatMap, T, In, Out](val in: In)(srv: Serve[T, F, In, Out]) {

--- a/modules/macros/src/main/scala/ru/tinkoff/tschema/macros/MakerMacro.scala
+++ b/modules/macros/src/main/scala/ru/tinkoff/tschema/macros/MakerMacro.scala
@@ -17,6 +17,8 @@ class MakerMacro(val c: blackbox.Context) extends ShapelessMacros with Singleton
   import c.universe._
   type WTTF[F[_]] = WeakTypeTag[F[Unit]]
 
+  val typeOfSkip: Type = c.typeOf[Any]
+
   def makeRouteHNilNoImpl[F[_]: WTTF, If: WeakTypeTag, Def: WeakTypeTag, Res: WeakTypeTag](
       definition: c.Expr[Def]): c.Expr[Res] =
     makeRouteImpl[F, If, Def, Unit, Res, HNil](definition)(none)(c.Expr(q"()"))
@@ -54,6 +56,8 @@ class MakerMacro(val c: blackbox.Context) extends ShapelessMacros with Singleton
     val ft        = weakTypeOf[F[Unit]].typeConstructor
     val dsl       = constructDslTree(defT, Monoid.empty[PrefixInfo[Type]])
     val wholeTree = new RouteTreeMaker(impl).makeRouteTree(ft, dsl, input.tree)
+
+    findMonadInstanceOrAbort(ft)
 
     infoTime(s"route $implT")
 
@@ -258,4 +262,16 @@ class MakerMacro(val c: blackbox.Context) extends ShapelessMacros with Singleton
     catch {
       case ex: TypecheckException => c.abort(c.enclosingPosition, ex.toString)
     }
+
+  private def findMonadInstanceOrAbort(tpe: Type): Unit = {
+    if (tpe != typeOfSkip) {
+      val implicitlyTree = q"""
+        _root_.scala.Predef.implicitly[cats.Monad[$tpe]]
+      """
+      val typechecked = c.typecheck(tree = implicitlyTree, silent = true)
+
+      if (typechecked.isEmpty)
+        c.abort(c.enclosingPosition, s"Monad instance for $tpe not found in:")
+    }
+  }
 }


### PR DESCRIPTION
When `ru.tinkoff.tschema.finagle.MkService` applied and no `cats.Monad` instance found for resulting effect type, the compiler reports counterintuitive "`Serve` instance not found" message.
This little PR address the described issue.