### PR TITLE
typed-schema version bump in examples

### DIFF
--- a/examples/project/Version.scala
+++ b/examples/project/Version.scala
@@ -11,6 +11,6 @@ object Version {
 
   val simulacrum = "1.0.0"
 
-  val typedSchema = "0.12.1"
+  val typedSchema = "0.12.2"
 
 }


### PR DESCRIPTION
Fixes compilation of `examples` module