### PR TITLE
Add discriminator property to generated typeables. Fix #113

### DIFF
--- a/modules/finagle-env/src/test/scala/ru/tinkoff/tschema/finagle/AuthorizationSpec.scala
+++ b/modules/finagle-env/src/test/scala/ru/tinkoff/tschema/finagle/AuthorizationSpec.scala
@@ -1,5 +1,7 @@
 package ru.tinkoff.tschema.finagle
 
+import scala.language.reflectiveCalls
+
 import com.twitter.finagle.http.Response
 import monix.eval.Task
 import org.scalatest.flatspec.AnyFlatSpec


### PR DESCRIPTION
Object schemas in oneOf/allOf must explicitly contains property named exactly as specified discriminator. This PR should fix SwaggerUI respresentation of sealed traits with discriminator property configured.

Reference: https://github.com/OAI/OpenAPI-Specification/blob/master/versions/3.0.1.md#discriminator-object