### PR TITLE
Fix optional AsSingleOpenApiParam

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@
 .attach_pid*
 metals.sbt
 .vscode
+.bsp

--- a/modules/swagger/src/main/scala/ru/tinkoff/tschema/swagger/AsOpenApiParam.scala
+++ b/modules/swagger/src/main/scala/ru/tinkoff/tschema/swagger/AsOpenApiParam.scala
@@ -27,6 +27,9 @@ object AsOpenApiParam extends AsOpenParamInstances[AsOpenApiParam] with Derivati
 
   def generate[T]: Typeclass[T] = macro Magnolia.gen[T]
   def instance[T]: Typeclass[T] = macro Magnolia.gen[T]
+
+  implicit def optParam[T](implicit param: AsOpenApiParam[T]): AsOpenApiParam[Option[T]] =
+    param.optional
 }
 
 trait OpenApiParamInfo {
@@ -46,10 +49,12 @@ final case class AsSingleOpenApiParam[T](typ: SwaggerType, required: Boolean = t
   def optional: AsOpenApiParam[Option[T]] = AsSingleOpenApiParam(typ, required = false)
 }
 
-object AsSingleOpenApiParam extends AsOpenParamInstances[AsSingleOpenApiParam]
+object AsSingleOpenApiParam extends AsOpenParamInstances[AsSingleOpenApiParam] {
+  final implicit def optSingleParam[T](implicit typ: SwaggerTypeable[T]): AsSingleOpenApiParam[Option[T]] =
+    AsSingleOpenApiParam[Option[T]](typ = typ.typ, required = false)
+}
 
 trait AsOpenParamInstances[TC[x] >: AsSingleOpenApiParam[x]] {
-  final implicit def requiredParam[T](implicit typ: SwaggerTypeable[T]): TC[T]                 =
+  final implicit def requiredSingleParam[T](implicit typ: SwaggerTypeable[T]): TC[T] =
     AsSingleOpenApiParam[T](typ = typ.typ, required = true)
-  final implicit def optParam[T](implicit param: AsOpenApiParam[T]): AsOpenApiParam[Option[T]] = param.optional
 }

--- a/modules/swagger/src/test/scala/ru/tinkoff/tschema/swagger/MkSwaggerSpec.scala
+++ b/modules/swagger/src/test/scala/ru/tinkoff/tschema/swagger/MkSwaggerSpec.scala
@@ -59,4 +59,18 @@ class MkSwaggerSpec extends AnyFlatSpec {
 
     assert((foo ++ bar).describe(description).make(OpenApiInfo()).tags == output)
   }
+
+  "optional header" should "has required = false in OpenAPI" in {
+    val swagger = MkSwagger(
+      (
+        tag("tag") :>
+          get :>
+          operation("operation") :>
+          header[Option[String]]("X-Kek-Id") :>
+          $$[String]
+      )
+    )
+
+    assert(!swagger.paths.head.op.parameters.find(_.name == "X-Kek-Id").get.required)
+  }
 }


### PR DESCRIPTION
Bug:

In case if AsSingleOpenApiParam for Option[T] and instance of SwaggerTypeable[Option[T]] is inferred, typed-schema picks AsOpenParamInstances.requiredParam branch as more simple than AsOpenParamInstances.optParam.
For example, `header[Option[String]]("X-Kek-Id")` will be required in OpenAPI.

This solution will fix it and safe other cases logic